### PR TITLE
Add logic for generating and getting the AWS Region IDs

### DIFF
--- a/internal/cloud/awsregions.go
+++ b/internal/cloud/awsregions.go
@@ -1,0 +1,123 @@
+package cloud
+
+import (
+	"sort"
+)
+
+// AWSRegions maps AWS region name -> increasing integer (stable order).
+// Indices are assigned deterministically. Regions listed in topAWSRegions
+// are guaranteed to take the first indices, in sorted(topAWSRegions) order.
+var AWSRegions = map[string]int{}
+
+// topAWSRegions lists the top regions for global coverage.
+// They will take the first IDs to ensure a global presence
+// even when only 3 bits are used to encode the cluster IDs.
+var topAWSRegions = []string{
+	"ap-southeast-2",
+	"eu-west-2",
+	"us-west-1",
+	"ap-east-1",
+	"af-south-1",
+	"sa-east-1",
+	"me-central-1",
+	"ca-central-1",
+}
+
+// allAWSRegions contains all available AWS regions.
+var allAWSRegions = []string{
+	"af-south-1",
+	"ap-east-1",
+	"ap-east-2",
+	"ap-northeast-1",
+	"ap-northeast-2",
+	"ap-northeast-3",
+	"ap-south-1",
+	"ap-south-2",
+	"ap-southeast-1",
+	"ap-southeast-2",
+	"ap-southeast-3",
+	"ap-southeast-4",
+	"ap-southeast-5",
+	"ap-southeast-6",
+	"ap-southeast-7",
+	"ca-central-1",
+	"ca-west-1",
+	"eu-central-1",
+	"eu-central-2",
+	"eu-north-1",
+	"eu-south-1",
+	"eu-south-2",
+	"eu-west-1",
+	"eu-west-2",
+	"eu-west-3",
+	"il-central-1",
+	"me-central-1",
+	"me-south-1",
+	"mx-central-1",
+	"sa-east-1",
+	"us-east-1",
+	"us-east-2",
+	"us-west-1",
+	"us-west-2",
+}
+
+// init builds the index maps using the current data.
+func init() {
+	rebuildAWSIndices()
+}
+
+// AWSRegionIndex returns the index for a region and whether it exists.
+func AWSRegionIndex(region string) (int, bool) {
+	i, ok := AWSRegions[region]
+	return i, ok
+}
+
+// rebuildAWSIndices rebuilds AWSRegions ensuring topAWSRegions come first.
+func rebuildAWSIndices() {
+	AWSRegions = map[string]int{}
+
+	// Collect regions
+	allRegions := make([]string, len(allAWSRegions))
+	copy(allRegions, allAWSRegions)
+	sort.Strings(allRegions)
+
+	// Top regions (that exist in the dataset), sorted
+	topRegions := make([]string, 0, len(topAWSRegions))
+	for _, r := range topAWSRegions {
+		if hasRegion(allAWSRegions, r) {
+			topRegions = append(topRegions, r)
+		}
+	}
+	sort.Strings(topRegions)
+
+	// Regions: top first, then the rest
+	topSet := make(map[string]struct{}, len(topRegions))
+	for _, r := range topRegions {
+		topSet[r] = struct{}{}
+	}
+	restRegions := make([]string, 0, len(allRegions))
+	for _, r := range allRegions {
+		if _, ok := topSet[r]; !ok {
+			restRegions = append(restRegions, r)
+		}
+	}
+
+	rIdx := 0
+	for _, r := range topRegions {
+		AWSRegions[r] = rIdx
+		rIdx++
+	}
+	for _, r := range restRegions {
+		AWSRegions[r] = rIdx
+		rIdx++
+	}
+}
+
+func hasRegion(regions []string, want string) bool {
+	for _, r := range regions {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cloud/generators/awsgen.go
+++ b/internal/cloud/generators/awsgen.go
@@ -1,0 +1,221 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"text/template"
+)
+
+// AWSRegion represents an AWS region from the AWS CLI output
+type AWSRegion struct {
+	Endpoint    string `json:"Endpoint"`
+	RegionName  string `json:"RegionName"`
+	OptInStatus string `json:"OptInStatus"`
+}
+
+// AWSRegionsOutput represents the output from describe-regions
+type AWSRegionsOutput struct {
+	Regions []AWSRegion `json:"Regions"`
+}
+
+// Config represents the template configuration
+type Config struct {
+	AllRegions []string
+	TopRegions []string
+}
+
+// TemplateData represents the data passed to the template
+type TemplateData struct {
+	Config Config
+}
+
+// parseTopRegions parses the top regions override flag format: "region1,region2,region3"
+func parseTopRegions(topRegionsFlag string) []string {
+	if topRegionsFlag == "" {
+		return []string{}
+	}
+
+	regions := strings.Split(topRegionsFlag, ",")
+	result := make([]string, 0, len(regions))
+	for _, region := range regions {
+		trimmed := strings.TrimSpace(region)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+// GenerateAWSRegionsFile runs AWS CLI commands and generates awsregions.go file
+func GenerateAWSRegionsFile(customTopRegions []string) error {
+	// Get AWS regions
+	regions, err := getAWSRegions()
+	if err != nil {
+		return fmt.Errorf("failed to get AWS regions: %w", err)
+	}
+
+	// Process regions into config
+	config := processRegionsIntoConfig(regions, customTopRegions)
+
+	// Generate the file from template
+	err = generateFileFromTemplate(config)
+	if err != nil {
+		return fmt.Errorf("failed to generate file from template: %w", err)
+	}
+
+	fmt.Println("Successfully generated awsregions.go")
+	return nil
+}
+
+// getAWSRegions runs AWS CLI to get all regions
+func getAWSRegions() ([]AWSRegion, error) {
+	cmd := exec.Command("aws", "ec2", "describe-regions", "--all-regions", "--output=json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to run aws ec2 describe-regions command: %w", err)
+	}
+
+	var regionsOutput AWSRegionsOutput
+	err = json.Unmarshal(output, &regionsOutput)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse JSON output: %w", err)
+	}
+
+	return regionsOutput.Regions, nil
+}
+
+// processRegionsIntoConfig converts regions into the config structure expected by the template
+func processRegionsIntoConfig(regions []AWSRegion, customTopRegions []string) Config {
+	allRegions := make([]string, 0, len(regions))
+
+	// Collect all opted-in regions
+	for _, region := range regions {
+		// Include regions that are opted-in or opt-in-not-required
+		if region.OptInStatus == "opted-in" || region.OptInStatus == "opt-in-not-required" {
+			allRegions = append(allRegions, region.RegionName)
+		}
+	}
+
+	sort.Strings(allRegions)
+
+	// Validate custom top regions
+	validTopRegions := make([]string, 0, len(customTopRegions))
+	regionSet := make(map[string]bool)
+	for _, r := range allRegions {
+		regionSet[r] = true
+	}
+
+	for _, region := range customTopRegions {
+		if regionSet[region] {
+			validTopRegions = append(validTopRegions, region)
+		} else {
+			fmt.Printf("Warning: Region '%s' not found in available regions\n", region)
+		}
+	}
+
+	return Config{
+		AllRegions: allRegions,
+		TopRegions: validTopRegions,
+	}
+}
+
+// generateFileFromTemplate generates the awsregions.go file using the template
+func generateFileFromTemplate(config Config) error {
+	// Read the template file (relative to current directory)
+	templatePath := "templates/awsregions.go.template"
+	templateContent, err := os.ReadFile(templatePath)
+	if err != nil {
+		return fmt.Errorf("failed to read template file: %w", err)
+	}
+
+	// Create custom template functions
+	funcMap := template.FuncMap{
+		"join": func(items []string, sep string) string {
+			// Quote each item and join with separator
+			quoted := make([]string, len(items))
+			for i, item := range items {
+				quoted[i] = fmt.Sprintf(`"%s"`, item)
+			}
+			return strings.Join(quoted, sep)
+		},
+	}
+
+	// Parse the template
+	tmpl, err := template.New("awsregions").Funcs(funcMap).Parse(string(templateContent))
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	// Create output directory if it doesn't exist (relative to project root)
+	outputDir := "../"
+	err = os.MkdirAll(outputDir, 0755)
+	if err != nil {
+		return fmt.Errorf("failed to create output directory: %w", err)
+	}
+
+	// Create output file
+	outputPath := filepath.Join(outputDir, "awsregions.go")
+	outputFile, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer outputFile.Close()
+
+	// Execute template
+	data := TemplateData{Config: config}
+	err = tmpl.Execute(outputFile, data)
+	if err != nil {
+		return fmt.Errorf("failed to execute template: %w", err)
+	}
+
+	return nil
+}
+
+func main() {
+	var (
+		topRegionsFlag string
+	)
+
+	flag.StringVar(&topRegionsFlag, "top-regions", "", "Override top regions in format 'region1,region2,region3' (exactly 2, 4 or 8 regions, e.g., 'us-east-1,eu-west-1,ap-southeast-1,us-west-2'). If not provided, uses default regions.")
+	flag.Parse()
+
+	var customTopRegions []string
+
+	if topRegionsFlag == "" {
+		// Use default hardcoded regions (8 regions for global coverage)
+		customTopRegions = []string{
+			"ap-southeast-2", // Sydney
+			"eu-west-2",      // London
+			"us-west-1",      // North California
+			"ap-east-1",      // Hong Kong
+			"af-south-1",     // South Africa, Cape Town
+			"sa-east-1",      // São Paulo
+			"me-central-1",   // Bahrain
+			"ca-central-1",   // Canada Central
+		}
+		fmt.Printf("Using default 8 top regions: %v\n", customTopRegions)
+		fmt.Println("Note: Ensure you have AWS credentials configured and the AWS CLI is accessible.")
+	} else {
+		// Parse the custom top regions
+		customTopRegions = parseTopRegions(topRegionsFlag)
+
+		// Validate that exactly 2, 4 or 8 top regions are provided
+		if len(customTopRegions) != 2 && len(customTopRegions) != 4 && len(customTopRegions) != 8 {
+			log.Fatalf("Error: You must provide exactly 2, 4 or 8 top regions, but you provided %d regions.\nProvided regions: %v", len(customTopRegions), customTopRegions)
+		}
+
+		fmt.Printf("Using %d custom top regions: %v\n", len(customTopRegions), customTopRegions)
+	}
+
+	err := GenerateAWSRegionsFile(customTopRegions)
+	if err != nil {
+		log.Fatalf("Error generating AWS regions file: %v", err)
+	}
+}

--- a/internal/cloud/generators/generate_all.sh
+++ b/internal/cloud/generators/generate_all.sh
@@ -15,8 +15,23 @@ else
     # Run the generator with the provided top zones
     go run gcpgen.go -top-zones "$1"
 fi
-# TODO: add generators for AWS and Azure
+
+echo ""
+echo "Generating AWS regions file..."
+# Check if top-regions flag is provided for AWS
+if [ $# -lt 2 ]; then
+    echo "Using default hardcoded regions..."
+    # Run the AWS generator with default regions
+    go run awsgen.go
+else
+    echo "Using custom top regions: $2"
+    # Run the AWS generator with the provided top regions
+    go run awsgen.go -top-regions "$2"
+fi
+
+# TODO: add generator for Azure
 
 go fmt ../
 
-echo "Generation completed successfully!"
+echo ""
+echo "All cloud zone/region files generated successfully!"

--- a/internal/cloud/generators/templates/awsregions.go.template
+++ b/internal/cloud/generators/templates/awsregions.go.template
@@ -1,0 +1,85 @@
+package cloud
+
+import (
+	"sort"
+)
+
+// AWSRegions maps AWS region name -> increasing integer (stable order).
+// Indices are assigned deterministically. Regions listed in topAWSRegions
+// are guaranteed to take the first indices, in sorted(topAWSRegions) order.
+var AWSRegions = map[string]int{}
+
+// topAWSRegions lists the top regions for global coverage.
+// They will take the first IDs to ensure a global presence
+// even when only 3 bits are used to encode the cluster IDs.
+var topAWSRegions = []string{
+  {{ range .Config.TopRegions }}{{ . | printf "%q" }},
+  {{ end }}
+}
+
+// allAWSRegions contains all available AWS regions.
+var allAWSRegions = []string{
+  {{ range .Config.AllRegions }}{{ . | printf "%q" }},
+  {{ end }}
+}
+
+// init builds the index maps using the current data.
+func init() {
+	rebuildAWSIndices()
+}
+
+// AWSRegionIndex returns the index for a region and whether it exists.
+func AWSRegionIndex(region string) (int, bool) {
+	i, ok := AWSRegions[region]
+	return i, ok
+}
+
+// rebuildAWSIndices rebuilds AWSRegions ensuring topAWSRegions come first.
+func rebuildAWSIndices() {
+	AWSRegions = map[string]int{}
+
+	// Collect regions
+	allRegions := make([]string, len(allAWSRegions))
+	copy(allRegions, allAWSRegions)
+	sort.Strings(allRegions)
+
+	// Top regions (that exist in the dataset), sorted
+	topRegions := make([]string, 0, len(topAWSRegions))
+	for _, r := range topAWSRegions {
+		if hasRegion(allAWSRegions, r) {
+			topRegions = append(topRegions, r)
+		}
+	}
+	sort.Strings(topRegions)
+
+	// Regions: top first, then the rest
+	topSet := make(map[string]struct{}, len(topRegions))
+	for _, r := range topRegions {
+		topSet[r] = struct{}{}
+	}
+	restRegions := make([]string, 0, len(allRegions))
+	for _, r := range allRegions {
+		if _, ok := topSet[r]; !ok {
+			restRegions = append(restRegions, r)
+		}
+	}
+
+	rIdx := 0
+	for _, r := range topRegions {
+		AWSRegions[r] = rIdx
+		rIdx++
+	}
+	for _, r := range restRegions {
+		AWSRegions[r] = rIdx
+		rIdx++
+	}
+}
+
+func hasRegion(regions []string, want string) bool {
+	for _, r := range regions {
+		if r == want {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/cloud/avaiabilityzones.go
+++ b/pkg/cloud/avaiabilityzones.go
@@ -24,12 +24,17 @@ const (
 
 // Additional errors for zone discovery.
 var (
+	ErrFailedToDetectProvider = errors.New("failed to detect cloud provider")
+	// Additional errors for GCP Zone discovery.
 	ErrGCPZoneNotFound        = errors.New("gcp zone not found")
 	ErrGCPMetadataUnavailable = errors.New("gcp metadata server unavailable")
-	ErrFailedToDetectProvider = errors.New("failed to detect cloud provider")
+
+	// Additional errors for AWS region discovery.
+	ErrAWSRegionNotFound      = errors.New("aws region not found")
+	ErrAWSMetadataUnavailable = errors.New("aws metadata server unavailable")
 )
 
-// GCPZone returns the GCP zone for the current pod's node.
+// gcpZone returns the GCP zone for the current pod's node.
 // It checks env overrides (GCP_ZONE, ZONE), then queries the metadata server:
 //
 //	http://metadata.google.internal/computeMetadata/v1/instance/zone
@@ -100,16 +105,102 @@ func gcpZoneId(ctx context.Context) (int, error) {
 	return -1, ErrGCPZoneNotFound
 }
 
+// awsRegion returns the AWS region for the current EC2 instance.
+// It checks env overrides (AWS_REGION, AWS_DEFAULT_REGION), then queries the metadata server:
+//
+//	http://169.254.169.254/latest/meta-data/placement/region
+//
+// Uses IMDSv2 with token-based authentication for security.
+func awsRegion(ctx context.Context) (string, error) {
+	// Env overrides (useful in tests or non-AWS environments)
+	if r := strings.TrimSpace(os.Getenv("AWS_REGION")); r != "" {
+		return r, nil
+	}
+	if r := strings.TrimSpace(os.Getenv("AWS_DEFAULT_REGION")); r != "" {
+		return r, nil
+	}
+
+	// AWS EC2 Instance Metadata Service v2 (IMDSv2)
+	base := "http://169.254.169.254"
+	tokenURL := base + "/latest/api/token"
+	regionURL := base + "/latest/meta-data/placement/region"
+
+	// First, get a session token (IMDSv2 requirement)
+	tokenReq, err := http.NewRequestWithContext(ctx, http.MethodPut, tokenURL, nil)
+	if err != nil {
+		return "", err
+	}
+	tokenReq.Header.Set("X-aws-ec2-metadata-token-ttl-seconds", "21600") // 6 hours
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	tokenResp, err := client.Do(tokenReq)
+	if err != nil {
+		return "", ErrAWSMetadataUnavailable
+	}
+	defer tokenResp.Body.Close()
+
+	if tokenResp.StatusCode != http.StatusOK {
+		return "", ErrAWSMetadataUnavailable
+	}
+
+	token, err := io.ReadAll(tokenResp.Body)
+	if err != nil {
+		return "", ErrAWSMetadataUnavailable
+	}
+
+	// Now get the region using the token
+	regionReq, err := http.NewRequestWithContext(ctx, http.MethodGet, regionURL, nil)
+	if err != nil {
+		return "", err
+	}
+	regionReq.Header.Set("X-aws-ec2-metadata-token", string(token))
+
+	regionResp, err := client.Do(regionReq)
+	if err != nil {
+		return "", ErrAWSMetadataUnavailable
+	}
+	defer regionResp.Body.Close()
+
+	if regionResp.StatusCode != http.StatusOK {
+		return "", ErrAWSMetadataUnavailable
+	}
+
+	body, err := io.ReadAll(regionResp.Body)
+	if err != nil {
+		return "", ErrAWSMetadataUnavailable
+	}
+
+	region := strings.TrimSpace(string(body))
+	if region == "" {
+		return "", ErrAWSRegionNotFound
+	}
+	return region, nil
+}
+
+func awsRegionId(ctx context.Context) (int, error) {
+	region, err := awsRegion(ctx)
+	if err != nil {
+		return -1, err
+	}
+	if i, ok := internal.AWSRegionIndex(region); ok {
+		return i, nil
+	}
+	return -1, ErrAWSRegionNotFound
+}
+
 func detectProvider(ctx context.Context) (Provider, error) {
 	// TODO: implement platform detection
 	return GCPProvider, nil
 }
 
 // AvailabilityZoneId returns the availability zone ID for the given provider.
+// For GCP, this returns the zone index. For AWS, this returns the region index.
 func AvailabilityZoneId(provider Provider) (int, error) {
 	switch provider {
 	case GCPProvider:
 		return gcpZoneId(context.Background())
+	case AWSProvider:
+		return awsRegionId(context.Background())
 	case DetectProvider:
 		detected, err := detectProvider(context.Background())
 		if err != nil {
@@ -117,7 +208,7 @@ func AvailabilityZoneId(provider Provider) (int, error) {
 		}
 		return AvailabilityZoneId(detected)
 	default:
-		// TODO: implement for AWS and Azure
+		// TODO: implement for Azure
 		return -1, fmt.Errorf("function not implemented for provider: %v", provider)
 	}
 }


### PR DESCRIPTION
Fix issue #3:

* Generate the AWS regions file based on all enabled regions from AWS.
* Allow overriding the top (using first IDs) regions for people who use less than 8 bits for the cluster
* Add logic for getting the region of the current AWS instance and mapping it to an ID.